### PR TITLE
Auth user

### DIFF
--- a/api/controllers/bookmark_controller.go
+++ b/api/controllers/bookmark_controller.go
@@ -6,17 +6,23 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/raylicola/NFlaquiz/database"
 	"github.com/raylicola/NFlaquiz/models"
+	"github.com/raylicola/NFlaquiz/utils"
 )
 
 // ブックマーク有無の更新
 // 受信：
-//   id: URLで指定 (/bookmark/:country_id/:user_id)
+//   id: URLで指定 (/bookmark/:country_id)
 func UpdateBookmark(c *gin.Context) {
 	var result models.Result
 	country_id := c.Param("country_id")
-	user_id := c.Param("user_id")
+	user, err := utils.AuthUser(c)
 
-	database.DB.Table("results").Where("country_id=?",country_id).Where("user_id=?",user_id).Find(&result)
+	// ユーザーが認証されていない場合
+	if err != nil {
+    c.JSON(http.StatusUnauthorized, gin.H{"err_msg": "認証されていません"})
+	}
+
+	database.DB.Table("results").Where("country_id=?",country_id).Where("user_id=?",user.ID).Find(&result)
 
 	if result.Bookmark == 1 {
 		result.Bookmark = 0

--- a/api/controllers/top_controller.go
+++ b/api/controllers/top_controller.go
@@ -7,13 +7,14 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/raylicola/NFlaquiz/database"
 	"github.com/raylicola/NFlaquiz/models"
+	"github.com/raylicola/NFlaquiz/utils"
 )
 
 // トップページ地図情報を取得
 // 返り値:
 //   成功時：[country_id,name,description, bookmark, weight]の配列
 func GetMapInfo(c *gin.Context) {
-	user, err := User(c)
+	user, err := utils.AuthUser(c)
 	var mapInfo []models.MapInfo
 	if err != nil {
 		// ログインしていない場合

--- a/api/controllers/user_controller.go
+++ b/api/controllers/user_controller.go
@@ -16,39 +16,13 @@ import (
 	"gorm.io/gorm"
 )
 
-// Cookieからユーザー情報を取得する
-// 戻り値:
-//   成功時：ユーザー情報
-//   失敗時：エラー情報
-func User(c *gin.Context) (*models.User, error){
-	cookie, err := c.Cookie("jwt")
-
-	if err != nil {
-		return nil, err
-	}
-
-	token, err := jwt.Parse(cookie, func(token *jwt.Token) (interface{}, error) {
-		return []byte("SECRET_KEY"), nil
-	})
-	if err != nil {
-		return nil, err
-	}
-	claims := token.Claims.(jwt.MapClaims)
-	id := claims["sub"]
-
-	var user models.User
-	database.DB.Where("id = ?", id).First(&user)
-
-	return &user, nil
-}
-
 
 // ログイン
 // 受信：
 //   email:メールアドレス
 //   password:パスワード
 // 返り値:
-//   成功時：jwtトークン
+//   成功時：ユーザー情報
 //   失敗時：エラーメッセージ(400)
 func Login(c *gin.Context) {
 	var user models.User
@@ -92,7 +66,7 @@ func Login(c *gin.Context) {
       c.SetCookie("jwt", cookie.Value, 3600, "/", "your_domain", true, true)
   }
 
-  c.JSON(http.StatusOK, gin.H{"jwt": tokenString})
+  c.JSON(http.StatusOK, gin.H{"user": user})
 }
 
 

--- a/api/routes/routes.go
+++ b/api/routes/routes.go
@@ -33,6 +33,6 @@ func GetRouter() *gin.Engine {
 	router.POST("/login", controllers.Login)
 	router.GET("/logout", controllers.Logout)
 	router.GET("/map", controllers.GetMapInfo)
-	router.POST("/bookmark/:country_id/:user_id", controllers.UpdateBookmark)
+	router.POST("/bookmark/:country_id", controllers.UpdateBookmark)
 	return router
 }

--- a/api/utils/auth_user.go
+++ b/api/utils/auth_user.go
@@ -1,0 +1,34 @@
+package utils
+
+import (
+	"github.com/dgrijalva/jwt-go"
+	"github.com/gin-gonic/gin"
+	"github.com/raylicola/NFlaquiz/database"
+	"github.com/raylicola/NFlaquiz/models"
+)
+
+// Cookieからユーザー認証を行う
+// 戻り値:
+//   成功時：ユーザー情報
+//   失敗時：エラー情報
+func AuthUser(c *gin.Context) (*models.User, error){
+	cookie, err := c.Cookie("jwt")
+
+	if err != nil {
+		return nil, err
+	}
+
+	token, err := jwt.Parse(cookie, func(token *jwt.Token) (interface{}, error) {
+		return []byte("SECRET_KEY"), nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	claims := token.Claims.(jwt.MapClaims)
+	id := claims["sub"]
+
+	var user models.User
+	database.DB.Where("id = ?", id).First(&user)
+
+	return &user, nil
+}


### PR DESCRIPTION
# 概要
* ユーザー認証処理の分離

# 変更内容
* ユーザー認証を行う関数を user_controller.go から分離
* リクエスト送信時にはユーザーIDを送信せず, API側でCookieから認証するように変更
* ログイン時にjwtトークンではなくユーザー情報を返すように変更
  * -> 分離には関係ないが, トークンを返す必要はなさそうだったため修正
```
変更前
http://localhost:8888/bookmark/US/1
変更後
http://localhost:8888/bookmark/US
```

# 補足
* bookmark/ にリクエストを送信するときはログインが必要
  * APIテスターで試すときは最初に /login する

```
例
1.
METHOD : POST
URL : http://localhost:8888/login
BODY : email = test1@com, pass = pass
2.
METHOD : POST
URL : http://localhost:8888/bookmark/US
```
