### PR TITLE
クイズ選択のロジックを大幅に変更

### DIFF
--- a/api/controllers/quiz_controller.go
+++ b/api/controllers/quiz_controller.go
@@ -1,7 +1,6 @@
 package controllers
 
 import (
-	"log"
 	"net/http"
 	"strconv"
 
@@ -105,9 +104,6 @@ func SelectQuiz(c *gin.Context) {
         Where("quizzes.country_id in (?)", country_array).
         Where("user_id = ?", user.ID).
         Order("weight").Limit(left).Find(&low_weight_quizzes)
-
-      log.Println(quizzes[0])
-      log.Println(low_weight_quizzes)
 
       database.DB.Raw(
 				"(?) UNION (?)",

--- a/api/controllers/quiz_controller.go
+++ b/api/controllers/quiz_controller.go
@@ -1,15 +1,15 @@
 package controllers
 
 import (
-  "log"
-  "net/http"
-  "strconv"
+	"log"
+	"net/http"
+	"strconv"
 
-  "github.com/gin-gonic/gin"
-  "github.com/raylicola/NFlaquiz/database"
-  "github.com/raylicola/NFlaquiz/models"
-  "github.com/raylicola/NFlaquiz/utils"
-  mapset "github.com/deckarep/golang-set/v2"
+	mapset "github.com/deckarep/golang-set/v2"
+	"github.com/gin-gonic/gin"
+	"github.com/raylicola/NFlaquiz/database"
+	"github.com/raylicola/NFlaquiz/models"
+	"github.com/raylicola/NFlaquiz/utils"
 )
 
 // 検索条件に当てはまるクイズを10問選ぶ
@@ -38,14 +38,14 @@ func SelectQuiz(c *gin.Context) {
   var flag_colors []models.FlagColor
   var results []models.Result
 
-  // 初めに全ての国を候補とする
+  // まずは全ての国を候補とする
   options := mapset.NewSet[string]()
   database.DB.Find(&countries)
   for _, v := range countries {
     options.Add(v.ID)
   }
 
-  // 地域が該当する国を絞る
+  // 該当地域の国を絞る
   if len(areas) != 0 {
     database.DB.Where("area_id in (?)", areas).Find(&countries)
     selected := mapset.NewSet[string]()
@@ -55,7 +55,7 @@ func SelectQuiz(c *gin.Context) {
     options = options.Intersect(selected)
   }
 
-  // 色が完全一致する国を絞る
+  // 国旗の色が完全一致する国を絞る
   if len(colors) != 0 {
     database.DB.Select("country_id").Where("color_id in (?)", colors).
       Group("country_id").Having("count(*) = ?", len(colors)).Find(&flag_colors)
@@ -66,7 +66,7 @@ func SelectQuiz(c *gin.Context) {
     options = options.Intersect(selected)
   }
 
-  // 該当ユーザーがブックマークした国を絞る
+  // ユーザーがブックマークした国を絞る
   if  (err == nil) && (bookmark == 1) {
     database.DB.Where("user_id=?", user.ID).Where("bookmark=?", bookmark).Find(&results)
     selected := mapset.NewSet[string]()
@@ -76,10 +76,46 @@ func SelectQuiz(c *gin.Context) {
     options = options.Intersect(selected)
   }
 
-  log.Println(options)
+  // 検索のための型変換
+  var country_array []string
+  options.Each(func(country string) bool {
+    country_array = append(country_array, country)
+    return false
+  })
 
   // 絞り込んだ国からクイズを選択
   var quizzes []models.Quiz
+
+  if err != nil {
+    // 未ログインユーザーの場合, ランダムにクイズを選択
+    database.DB.Where("quizzes.country_id in (?)", country_array).
+      Order("rand()").Limit(10).Find(&quizzes)
+  } else {
+    // ログイン済みユーザーの場合, 未回答のものを優先して選択
+    query := database.DB.Joins("left outer join results on quizzes.country_id = results.country_id").
+      Where("quizzes.country_id in (?)", country_array).
+      Where("quizzes.country_id not in (?)", database.DB.Table("results").Select("country_id").Where("user_id=?", user.ID)).
+      Order("rand()").Limit(10).Find(&quizzes)
+
+    // 未回答問題数が10未満の場合, 正答率が低い順に残りを埋める
+    left := int(10 - query.RowsAffected)
+    if left > 0 {
+      var low_weight_quizzes []models.Quiz
+      low_weight_query := database.DB.Joins("left outer join results on quizzes.country_id = results.country_id").
+        Where("quizzes.country_id in (?)", country_array).
+        Where("user_id = ?", user.ID).
+        Order("weight").Limit(left).Find(&low_weight_quizzes)
+
+      log.Println(quizzes[0])
+      log.Println(low_weight_quizzes)
+
+      database.DB.Raw(
+				"(?) UNION (?)",
+				query,
+				low_weight_query,
+			).Scan(&quizzes)
+    }
+  }
 
   c.JSON(http.StatusOK, gin.H{"quizzes": quizzes})
 }

--- a/api/controllers/quiz_controller.go
+++ b/api/controllers/quiz_controller.go
@@ -34,47 +34,51 @@ func SelectQuiz(c *gin.Context) {
   bookmark, _ := strconv.Atoi(req.Bookmark)
   user, err := utils.AuthUser(c)
 
-  // 地域が該当する国
-  if len(areas) == 0 {
-    areas = append(areas, "Africa", "Asia", "Europe", "LatinAmericaandCaribbean",
-                          "MiddleEast", "NorthAmerica", "Oceania")
-  }
   var countries []models.Country
-  database.DB.Where("area_id in (?)", areas).Find(&countries)
-  options1 := mapset.NewSet[string]()
-  for _, v := range countries {
-    options1.Add(v.ID)
-  }
-
-  // 色が完全一致する国
   var flag_colors []models.FlagColor
-  database.DB.Select("country_id").Where("color_id in (?)", colors).
-    Group("country_id").Having("count(*) >= ?", len(colors)).Find(&flag_colors)
-  options2 := mapset.NewSet[string]()
-  for _, v := range flag_colors {
-    options2.Add(v.CountryID)
+  var results []models.Result
+
+  // 初めに全ての国を候補とする
+  options := mapset.NewSet[string]()
+  database.DB.Find(&countries)
+  for _, v := range countries {
+    options.Add(v.ID)
   }
 
-  // 該当ユーザーがブックマークした国
-  var results []models.Result
-  options3 := mapset.NewSet[string]()
+  // 地域が該当する国を絞る
+  if len(areas) != 0 {
+    database.DB.Where("area_id in (?)", areas).Find(&countries)
+    selected := mapset.NewSet[string]()
+    for _, v := range countries {
+      selected.Add(v.ID)
+    }
+    options = options.Intersect(selected)
+  }
+
+  // 色が完全一致する国を絞る
+  if len(colors) != 0 {
+    database.DB.Select("country_id").Where("color_id in (?)", colors).
+      Group("country_id").Having("count(*) = ?", len(colors)).Find(&flag_colors)
+    selected := mapset.NewSet[string]()
+    for _, v := range flag_colors {
+      selected.Add(v.CountryID)
+    }
+    options = options.Intersect(selected)
+  }
+
+  // 該当ユーザーがブックマークした国を絞る
   if  (err == nil) && (bookmark == 1) {
     database.DB.Where("user_id=?", user.ID).Where("bookmark=?", bookmark).Find(&results)
+    selected := mapset.NewSet[string]()
     for _, v := range results {
-      options3.Add(v.CountryID)
+      selected.Add(v.CountryID)
     }
-  } else {
-    database.DB.Find(&countries)
-    for _, v := range countries {
-      options3.Add(v.ID)
-    }
+    options = options.Intersect(selected)
   }
 
-  // 全ての絞り込み条件に一致した国
-  options :=options1.Intersect(options2).Intersect(options3)
   log.Println(options)
 
-  // クイズを選択
+  // 絞り込んだ国からクイズを選択
   var quizzes []models.Quiz
 
   c.JSON(http.StatusOK, gin.H{"quizzes": quizzes})

--- a/api/controllers/quiz_controller.go
+++ b/api/controllers/quiz_controller.go
@@ -1,14 +1,15 @@
 package controllers
 
 import (
-	"log"
-	"net/http"
-	"strconv"
+  "log"
+  "net/http"
+  "strconv"
 
-	"github.com/gin-gonic/gin"
-	"github.com/raylicola/NFlaquiz/database"
-	"github.com/raylicola/NFlaquiz/models"
-	"github.com/raylicola/NFlaquiz/utils"
+  "github.com/gin-gonic/gin"
+  "github.com/raylicola/NFlaquiz/database"
+  "github.com/raylicola/NFlaquiz/models"
+  "github.com/raylicola/NFlaquiz/utils"
+  mapset "github.com/deckarep/golang-set/v2"
 )
 
 // 検索条件に当てはまるクイズを10問選ぶ
@@ -16,71 +17,65 @@ import (
 // 受信：
 //   colors(array): 選択された色
 //    areas(array): 選択された地域
-//  bookmark(int): ブックマークで絞り込むか否か
-//                 0:絞り込みを行わない, 1:行う
+//   bookmark(int): ブックマークで絞り込むか否か
 // 戻り値：
 //    10問以下のクイズセット
 func SelectQuiz(c *gin.Context) {
 
-	// クエリパラメータをバインド
-	var req models.QuizFilter
-	if err := c.Bind(&req); err != nil {
-		c.JSON(http.StatusBadRequest, err)
-		return
-	}
+  // 絞り込み条件を取得
+  var req models.QuizFilter
+  if err := c.Bind(&req); err != nil {
+    c.JSON(http.StatusBadRequest, err)
+    return
+  }
 
-	colors := req.Colors
-	areas := req.Areas
-	bookmark, _ := strconv.Atoi(req.Bookmark)
-	user, err := utils.AuthUser(c)
-	log.Println(bookmark)
+  colors := req.Colors
+  areas := req.Areas
+  bookmark, _ := strconv.Atoi(req.Bookmark)
+  user, err := utils.AuthUser(c)
 
-	// クイズを選択
-	// TODO: 可能であれば色はAND検索に修正
-	var quizzes []models.Quiz
+  // 地域が該当する国
+  if len(areas) == 0 {
+    areas = append(areas, "Africa", "Asia", "Europe", "LatinAmericaandCaribbean",
+                          "MiddleEast", "NorthAmerica", "Oceania")
+  }
+  var countries []models.Country
+  database.DB.Where("area_id in (?)", areas).Find(&countries)
+  options1 := mapset.NewSet[string]()
+  for _, v := range countries {
+    options1.Add(v.ID)
+  }
 
-	if err != nil {
-    // 1. ログインしていない場合
-		// 条件に合うものをランダムに選択
-		database.DB.Distinct("quizzes.id, hiragana, quizzes.country_id, hint1, hint2, hint3").Joins("left join countries on quizzes.country_id = countries.id").Joins("left join flag_colors on quizzes.country_id = flag_colors.country_id").Where("color_id in (?)", colors).Where("area_id in (?)", areas).Order("rand()").Limit(10).Find(&quizzes)
+  // 色が完全一致する国
+  var flag_colors []models.FlagColor
+  database.DB.Select("country_id").Where("color_id in (?)", colors).
+    Group("country_id").Having("count(*) >= ?", len(colors)).Find(&flag_colors)
+  options2 := mapset.NewSet[string]()
+  for _, v := range flag_colors {
+    options2.Add(v.CountryID)
+  }
 
-	} else {
+  // 該当ユーザーがブックマークした国
+  var results []models.Result
+  options3 := mapset.NewSet[string]()
+  if  (err == nil) && (bookmark == 1) {
+    database.DB.Where("user_id=?", user.ID).Where("bookmark=?", bookmark).Find(&results)
+    for _, v := range results {
+      options3.Add(v.CountryID)
+    }
+  } else {
+    database.DB.Find(&countries)
+    for _, v := range countries {
+      options3.Add(v.ID)
+    }
+  }
 
-		// 2. ログイン済みの場合
-		// 2-1.ブックマークで絞る場合
-		// 正答率が低い順に10問選択
-		if bookmark == 1 {
+  // 全ての絞り込み条件に一致した国
+  options :=options1.Intersect(options2).Intersect(options3)
+  log.Println(options)
 
-			database.DB.Distinct("quizzes.id, hiragana, quizzes.country_id, hint1, hint2, hint3, weight").Joins("left join countries on quizzes.country_id = countries.id").Joins("left join flag_colors on quizzes.country_id = flag_colors.country_id").Joins("left join results on results.country_id = quizzes.country_id").Where("user_id=?", user.ID).Where("bookmark=1").Where("color_id in (?)", colors).Where("area_id in (?)", areas).Order("weight").Limit(10).Find(&quizzes)
+  // クイズを選択
+  var quizzes []models.Quiz
 
-		} else {
-
-			// 2-2. ブックマークで絞らない場合
-			var quizzes1 []models.Quiz
-			var quizzes2 []models.Quiz
-			// (1)該当ユーザーの正答率が低いクイズ
-			// weight <= 0.5 と定義
-			query1 := database.DB.Distinct("quizzes.id, hiragana, quizzes.country_id, hint1, hint2, hint3").Joins("left join results on quizzes.country_id = results.country_id").Joins("left join countries on quizzes.country_id = countries.id").Joins("left join flag_colors on quizzes.country_id = flag_colors.country_id").Where("user_id=?", user.ID).Where("weight<=0.5").Where("color_id in (?)", colors).Where("area_id in (?)", areas).Find(&quizzes1)
-
-			// (2)該当ユーザーが未回答のクイズ
-			query2 := database.DB.Distinct("quizzes.id, hiragana, quizzes.country_id, hint1, hint2, hint3").Joins("left join results on quizzes.country_id = results.country_id").Joins("left join countries on quizzes.country_id = countries.id").Joins("left join flag_colors on quizzes.country_id = flag_colors.country_id").Where("quizzes.country_id not in (?)", database.DB.Table("results").Select("country_id").Where("user_id=?", user.ID)).Where("color_id in (?)", colors).Where("area_id in (?)", areas).Find(&quizzes2)
-
-			// (1)と(2)の中からランダムに選択
-			database.DB.Raw(
-				"? UNION ? ORDER BY rand() LIMIT 10",
-				query1,
-				query2,
-			).Scan(&quizzes)
-
-			// 10問に満たない場合は残りをweight>0.5のものから昇順で選択
-			if len(quizzes) < 10 {
-				var quizzes3 []models.Quiz
-				query1 = database.DB.Distinct("quizzes.id, hiragana, quizzes.country_id, hint1, hint2, hint3, weight").Joins("left join results on quizzes.country_id = results.country_id").Joins("left join countries on quizzes.country_id = countries.id").Joins("left join flag_colors on quizzes.country_id = flag_colors.country_id").Where("user_id=?", user.ID).Where("weight>0.5").Where("color_id in (?)", colors).Where("area_id in (?)", areas).Order("weight").Limit(10-len(quizzes)).Find(&quizzes3)
-
-				quizzes = append(quizzes, quizzes3...)
-			}
-		}
-	}
-
-	c.JSON(http.StatusOK, gin.H{"quizzes": quizzes})
+  c.JSON(http.StatusOK, gin.H{"quizzes": quizzes})
 }

--- a/api/go.mod
+++ b/api/go.mod
@@ -11,6 +11,7 @@ require (
 )
 
 require (
+	github.com/deckarep/golang-set/v2 v2.1.0 // indirect
 	github.com/gin-contrib/cors v1.3.1 // indirect
 	github.com/gin-contrib/sse v0.1.0 // indirect
 	github.com/go-playground/locales v0.13.0 // indirect

--- a/api/go.sum
+++ b/api/go.sum
@@ -1,6 +1,8 @@
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/deckarep/golang-set/v2 v2.1.0 h1:g47V4Or+DUdzbs8FxCCmgb6VYd+ptPAngjM6dtGktsI=
+github.com/deckarep/golang-set/v2 v2.1.0/go.mod h1:VAky9rY/yGXJOLEDv3OMci+7wtDpOF4IN+y82NBOac4=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/gin-contrib/cors v1.3.1 h1:doAsuITavI4IOcd0Y19U4B+O0dNWihRyX//nn4sEmgA=

--- a/api/models/country.go
+++ b/api/models/country.go
@@ -1,0 +1,9 @@
+package models
+
+type Country struct {
+	ID      		string
+	AreaID  		string
+	Name    		string
+	Description string
+
+}

--- a/api/models/flag_color.go
+++ b/api/models/flag_color.go
@@ -1,0 +1,7 @@
+package models
+
+type FlagColor struct {
+	ID        int
+	CountryID string
+	ColorID   string
+}

--- a/api/models/quiz_filter.go
+++ b/api/models/quiz_filter.go
@@ -1,7 +1,7 @@
 package models
 
 type QuizFilter struct {
-	Colors    []string  `form:"colors[]" binding:"required"`
-	Areas     []string  `form:"areas[]" binding:"required"`
-	Bookmark  string    `form:"bookmark" binding:"required"`
+	Colors    []string  `form:"colors[]"`
+	Areas     []string  `form:"areas[]"`
+	Bookmark  string    `form:"bookmark"`
 }


### PR DESCRIPTION
# 変更内容
- 条件ごとに一発のSQL文でクイズ選択していた処理を, 絞り込み種類ごとに国を絞りこんで積集合をとる方法に変更

# 影響範囲
- クエリパラメータの受け渡し方法

## パラメータの種類
- 全てのパラメータは必須ではなく, 指定がなければデフォルト値が採用される 
- 指定がないものについては絞り込みが行われないという認識でOK

| パラメータ | デフォルト値 | 備考                                      | 
| :--------: | :--------: | :---------------------------------------: | 
| areas[]    | []         | 選択地域のうちのどれかに該当する国.       | 
| colors[]   | []         | 選択色をすべて含む国旗をもつ国            | 
| bookmark   | 0          | ブックマークした国で絞り込む場合は1を指定 | 

## URL指定例
- 地域は指定せず, 国旗に白と青を含み, ユーザーがブックマークした国からクイズを選択したい場合
```
http://localhost:8888/quiz/select?colors[]=white&colors[]=blue&bookmark=1
```
