### PR TITLE
初期挿入データに改行コードが含まれないよう修正

### DIFF
--- a/docker/mysql/initdb.d/2_load_data.sh
+++ b/docker/mysql/initdb.d/2_load_data.sh
@@ -6,7 +6,7 @@ mysql -u$MYSQL_USER -p$MYSQL_PASSWORD $MYSQL_DATABASE --local-infile=1 -e "LOAD 
 
 mysql -u$MYSQL_USER -p$MYSQL_PASSWORD $MYSQL_DATABASE --local-infile=1 -e "LOAD DATA LOCAL INFILE './csv/Countries.csv' INTO TABLE countries FIELDS TERMINATED BY ',' ENCLOSED BY '\"' LINES TERMINATED BY '\n' IGNORE 1 LINES;"
 
-mysql -u$MYSQL_USER -p$MYSQL_PASSWORD $MYSQL_DATABASE --local-infile=1 -e "LOAD DATA LOCAL INFILE './csv/Quizzes.csv' INTO TABLE quizzes FIELDS TERMINATED BY ',' ENCLOSED BY '\"' LINES TERMINATED BY '\n' IGNORE 1 LINES (@1,@2,@3,@4,@5) SET hiragana=@1, country_id=@2, hint1=@3, hint2=@4, hint3=@5;"
+mysql -u$MYSQL_USER -p$MYSQL_PASSWORD $MYSQL_DATABASE --local-infile=1 -e "LOAD DATA LOCAL INFILE './csv/Quizzes.csv' INTO TABLE quizzes FIELDS TERMINATED BY ',' ENCLOSED BY '\"' LINES TERMINATED BY '\r\n' IGNORE 1 LINES (@1,@2,@3,@4,@5) SET hiragana=@1, country_id=@2, hint1=@3, hint2=@4, hint3=@5;"
 
 mysql -u$MYSQL_USER -p$MYSQL_PASSWORD $MYSQL_DATABASE --local-infile=1 -e "LOAD DATA LOCAL INFILE './csv/FlagColors.csv' INTO TABLE flag_colors FIELDS TERMINATED BY ',' ENCLOSED BY '\"' LINES TERMINATED BY '\r\n' IGNORE 1 LINES (@1,@2) SET country_id=@1, color_id=@2;"
 


### PR DESCRIPTION
# 概要
- クイズの初期挿入データに改行コードが含まれないよう修正

# 動作要件
- volume 削除 -> コンテナ再起動

# 解決する Issue
- close #17 