### PR TITLE
ブックマーク削除モーダルのテーブルのレイアウト修正

### DIFF
--- a/ui/src/components/EditBookmark.vue
+++ b/ui/src/components/EditBookmark.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="modal fade" id="editBookmark" tabindex="-1" aria-labelledby="editBookmarkTitle" aria-hidden="false">
-    <div class="modal-dialog modal-lg modal-dialog-centered">
+    <div class="modal-dialog modal-dialog-centered">
       <div class="modal-content quiz-filter">
         <div class="modal-header p-0 border-bottom-0">
           <h2 class="modal-title" id="editBookmarkTitle">ブックマーク編集</h2>

--- a/ui/src/components/EditBookmark.vue
+++ b/ui/src/components/EditBookmark.vue
@@ -15,10 +15,10 @@
                 <table class="table table-striped table-hover">
                   <tbody>
                     <tr v-for="value in bookMarks" :key="value.name">
-                      <td scope="col" style="width: 80%">
+                      <td scope="col" class="align-middle" style="width: 80%">
                         {{ value.name }}
                       </td>
-                      <td scope="col" style="width: 20%">
+                      <td scope="col" class="align-middle" style="width: 20%">
                         <button class="btn btn-danger" v-on:click="deleteBookmark(value.id)">削除</button>
                       </td>
                     </tr>

--- a/ui/src/components/EditBookmark.vue
+++ b/ui/src/components/EditBookmark.vue
@@ -1,5 +1,6 @@
 <template>
-  <div class="modal fade" id="editBookmark" tabindex="-1" aria-labelledby="editBookmarkTitle" aria-hidden="false">
+  <div class="modal fade" id="editBookmark" tabindex="-1" aria-labelledby="editBookmarkTitle" data-backdrop="static"
+    aria-hidden="false">
     <div class="modal-dialog modal-dialog-centered">
       <div class="modal-content quiz-filter">
         <div class="modal-header ml-3 p-0 border-bottom-0">

--- a/ui/src/components/EditBookmark.vue
+++ b/ui/src/components/EditBookmark.vue
@@ -2,7 +2,7 @@
   <div class="modal fade" id="editBookmark" tabindex="-1" aria-labelledby="editBookmarkTitle" aria-hidden="false">
     <div class="modal-dialog modal-dialog-centered">
       <div class="modal-content quiz-filter">
-        <div class="modal-header p-0 border-bottom-0">
+        <div class="modal-header ml-3 p-0 border-bottom-0">
           <h2 class="modal-title" id="editBookmarkTitle">ブックマーク編集</h2>
           <button type="button" class="close modal-close" data-dismiss="modal" @click="reload" aria-label="Close">
             <i class="bi bi-x-square"></i>

--- a/ui/src/components/EditBookmark.vue
+++ b/ui/src/components/EditBookmark.vue
@@ -1,6 +1,5 @@
 <template>
-  <div class="modal fade" id="editBookmark" tabindex="-1" aria-labelledby="editBookmarkTitle"
-    aria-hidden="false">
+  <div class="modal fade" id="editBookmark" tabindex="-1" aria-labelledby="editBookmarkTitle" aria-hidden="false">
     <div class="modal-dialog modal-lg modal-dialog-centered">
       <div class="modal-content quiz-filter">
         <div class="modal-header p-0 border-bottom-0">
@@ -16,8 +15,10 @@
                 <table class="table table-striped table-hover">
                   <tbody>
                     <tr v-for="value in bookMarks" :key="value.name">
-                      <td>{{ value.name }}</td>
-                      <td>
+                      <td scope="col" style="width: 80%">
+                        {{ value.name }}
+                      </td>
+                      <td scope="col" style="width: 20%">
                         <button class="btn btn-danger" v-on:click="deleteBookmark(value.id)">削除</button>
                       </td>
                     </tr>

--- a/ui/src/components/EditBookmark.vue
+++ b/ui/src/components/EditBookmark.vue
@@ -15,10 +15,10 @@
                 <table class="table table-striped table-hover">
                   <tbody>
                     <tr v-for="value in bookMarks" :key="value.name">
-                      <td scope="col" class="align-middle" style="width: 80%">
+                      <td scope="col" class="align-middle" style="width: 70%; font-size: 24px;">
                         {{ value.name }}
                       </td>
-                      <td scope="col" class="align-middle" style="width: 20%">
+                      <td scope="col" class="align-middle" style="width: 30%;">
                         <button class="btn btn-danger" v-on:click="deleteBookmark(value.id)">削除</button>
                       </td>
                     </tr>


### PR DESCRIPTION
# 概要
fixes #41
列の長さを70％，30％に指定
モーダルが横長だったので小さくした
fixes #39 
Xボタンを押すと更新がかかるものだったが，モーダル外を押すと更新がかからなかったので，モーダル外を押しても閉じないようにした

# 変更内容
* 変更前
![FireShot Capture 045 - ui - localhost](https://user-images.githubusercontent.com/68259230/213753560-2906c877-14f8-4136-8c08-3ba854731a09.png)
* 変更後
![FireShot Capture 044 - ui - localhost](https://user-images.githubusercontent.com/68259230/213753605-c5a5db7c-547c-49c9-a70b-83354ac1967c.png)

cosed #39 , closes #41