### PR TITLE
ヒントを配列で返す仕様に変更

### DIFF
--- a/api/controllers/quiz_controller.go
+++ b/api/controllers/quiz_controller.go
@@ -154,9 +154,7 @@ func SelectQuiz(c *gin.Context) {
       ID: quiz.ID,
       CountryName: quiz.CountryName,
       CountryID: quiz.CountryID,
-      Hint1: quiz.Hint1,
-      Hint2: quiz.Hint2,
-      Hint3: quiz.Hint3,
+      Hints: []string{quiz.Hint1, quiz.Hint2, quiz.Hint3},
       Options: name_options[i],
     })
   }

--- a/api/models/quiz_with_option.go
+++ b/api/models/quiz_with_option.go
@@ -4,8 +4,6 @@ type QuizWithOption struct {
 	ID          int
 	CountryName string
 	CountryID   string
-	Hint1       string
-	Hint2       string
-	Hint3       string
+	Hints       []string
 	Options     []string
 }


### PR DESCRIPTION
# 概要
クイズを返すAPIの返り値の仕様変更
- ヒントを配列で返す仕様に変更

<img width="610" alt="スクリーンショット 2023-01-21 10 01 44" src="https://user-images.githubusercontent.com/76393580/213830861-f4d0707d-0402-4220-ac09-19b8db190c06.png">
