### PR TITLE
 close ボタンについているフォーカス時の枠線削除

### DIFF
--- a/ui/public/styles/overwrite.css
+++ b/ui/public/styles/overwrite.css
@@ -214,6 +214,10 @@ button.modal-close {
   border: 0;
 }
 
+.modal-close:focus, .modal-close.focus {
+  outline: none;
+}
+
 .modal-sm {
   max-width: 232px;
 }


### PR DESCRIPTION
# 概要
モーダルのclose ボタンについているフォーカス時の枠線を削除しました

# 変更内容
modal-close クラスの focus に `outline: none` 設定

# 解決するIssue
close #66 
